### PR TITLE
fix: chayote/ cho cho / choko, low fodmap

### DIFF
--- a/fodmap_repo.json
+++ b/fodmap_repo.json
@@ -497,16 +497,16 @@
   {
     "id": "74",
     "name": "Chayote / choko",
-    "fodmap": "high",
+    "fodmap": "low",
     "category": "Vegetables and legumes",
-	"details": {"oligos":2,"fructose":0,"polyols":0,"lactose":0}
+	"details": {"oligos":0,"fructose":0,"polyols":0,"lactose":0}
   },
   {
     "id": "75",
     "name": "Cho Cho",
-    "fodmap": "high",
+    "fodmap": "low",
     "category": "Vegetables and legumes",
-	"details": {"oligos":2,"fructose":0,"polyols":0,"lactose":0}
+	"details": {"oligos":0,"fructose":0,"polyols":0,"lactose":0}
   },
   {
     "id": "76",


### PR DESCRIPTION
Changing cho cho / chayote / choko, from high fodmap to low fodmap, acording to these sources (couldn't find a paper):
* https://whole30.com/downloads/whole30-shopping-list-FODMAP.pdf
* https://glutenfreecuppatea.co.uk/low-high-fodmap-food-list-diet/
* https://medigest.com.br/dieta-com-baixo-teor-de-fodmaps/
* https://vegmag.com.br/blogs/alimentacao/saiba-o-que-e-fodmap-e-preserve-seu-intestino

The last two is in portuguese, and states that chuchu (chayote) is low FODMAP.